### PR TITLE
Fix docker run example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ $ docker pull docker.pkg.github.com/olivia-ai/olivia/olivia:latest
 
 Then start it
 ```bash
-$ docker run -d -p 8080:8080 docker.pkg.github.com/olivia-ai/olivia/olivia:latest
+$ docker run -d -e PORT=8080 -p 8080:8080 docker.pkg.github.com/olivia-ai/olivia/olivia:latest
 ```
 
 You can just use the websocket of Olivia now.


### PR DESCRIPTION
The example for running the backend through docker was missing the addition of `-e PORT=8080` that was made some time ago on the README of its respective repository, and was causing errors.